### PR TITLE
Issue 22

### DIFF
--- a/sdk/pipeline.go
+++ b/sdk/pipeline.go
@@ -110,24 +110,25 @@ func (pipeline *Pipeline) MakeDotGraph() string {
 	sb.WriteString("digraph depgraph {\n\trankdir=LR;\n")
 	for _, node := range pipeline.Dag.nodes {
 		if len(node.children) == 0 {
-			sb.WriteString(fmt.Sprintf("\t\"%s\";\n", node.Id))
+			sb.WriteString(fmt.Sprintf("\"%s\";\n", node.Id))
 			continue
 		}
 		modifierType := ""
 		for _, operation := range node.Operations() {
 			switch {
 			case operation.Function != "":
-				modifierType += " func:" + operation.Function
+				modifierType += "(func)" + operation.Function
 			case operation.CallbackUrl != "":
-				modifierType += " callback:" + operation.CallbackUrl
+				modifierType += "(callback)" + operation.CallbackUrl
 			default:
-				modifierType += " modifier"
+				modifierType += "(modifier)"
 			}
 		}
 
 		for _, child := range node.children {
-			sb.WriteString(fmt.Sprintf(`%s -> %s [label="%v"]`, node.Id, child.Id, modifierType))
-			sb.WriteString("\r\n")
+			sb.WriteString("\t")
+			sb.WriteString(fmt.Sprintf(`"%s" -> "%s" [label="%v"]`, node.Id, child.Id, modifierType))
+			sb.WriteString("\n")
 		}
 	}
 	sb.WriteString("}\n")

--- a/sdk/pipeline.go
+++ b/sdk/pipeline.go
@@ -110,14 +110,14 @@ func (pipeline *Pipeline) MakeDotGraph() string {
 	sb.WriteString("digraph depgraph {\n\trankdir=LR;\n")
 	for _, node := range pipeline.Dag.nodes {
 		if len(node.children) == 0 {
-			sb.WriteString(fmt.Sprintf("\"%s\";\n", node.Id))
+			sb.WriteString(fmt.Sprintf("\t\"%s\";\n", node.Id))
 			continue
 		}
 		modifierType := ""
 		for _, operation := range node.Operations() {
 			switch {
 			case operation.Function != "":
-				modifierType += "(func)" + operation.Function
+				modifierType += "(func-" + operation.Function + ")"
 			case operation.CallbackUrl != "":
 				modifierType += "(callback)" + operation.CallbackUrl
 			default:

--- a/template/faas-flow/handler.go
+++ b/template/faas-flow/handler.go
@@ -889,3 +889,35 @@ func handleWorkflow(data []byte) string {
 
 	return string(resp)
 }
+
+// handleDotGraph() handle the dot graph request
+func handleDotGraph() string {
+	fhandler := newWorkflowHandler("", "", "", "", nil)
+	context := createContext(fhandler)
+
+	err := function.Define(fhandler.flow, context)
+	if err != nil {
+		log.Fatalf("failed to generate dot graph, error %v", err)
+	}
+	return fhandler.getPipeline().MakeDotGraph()
+}
+
+// isDotGraphRequest check if the request is for dot graph generation
+func isDotGraphRequest() bool {
+	values, err := url.ParseQuery(os.Getenv("Http_Query"))
+	if err != nil {
+		return false
+	}
+	if strings.ToUpper(values.Get("generate-dot-graph")) == "TRUE" {
+		return true
+	}
+	return false
+}
+
+// handle handle the requests
+func handle(data []byte) string {
+	if isDotGraphRequest() {
+		return handleDotGraph()
+	}
+	return handleWorkflow(data)
+}

--- a/template/faas-flow/main.go
+++ b/template/faas-flow/main.go
@@ -13,5 +13,5 @@ func main() {
 		log.Fatalf("Unable to read standard input: %s", err.Error())
 	}
 
-	fmt.Println(handleWorkflow(input))
+	fmt.Println(handle(input))
 }

--- a/template/faas-flow/vendor/github.com/s8sg/faas-flow/sdk/pipeline.go
+++ b/template/faas-flow/vendor/github.com/s8sg/faas-flow/sdk/pipeline.go
@@ -110,24 +110,25 @@ func (pipeline *Pipeline) MakeDotGraph() string {
 	sb.WriteString("digraph depgraph {\n\trankdir=LR;\n")
 	for _, node := range pipeline.Dag.nodes {
 		if len(node.children) == 0 {
-			sb.WriteString(fmt.Sprintf("\t\"%s\";\n", node.Id))
+			sb.WriteString(fmt.Sprintf("\"%s\";\n", node.Id))
 			continue
 		}
 		modifierType := ""
 		for _, operation := range node.Operations() {
 			switch {
 			case operation.Function != "":
-				modifierType += " func:" + operation.Function
+				modifierType += "(func)" + operation.Function
 			case operation.CallbackUrl != "":
-				modifierType += " callback:" + operation.CallbackUrl
+				modifierType += "(callback)" + operation.CallbackUrl
 			default:
-				modifierType += " modifier"
+				modifierType += "(modifier)"
 			}
 		}
 
 		for _, child := range node.children {
-			sb.WriteString(fmt.Sprintf(`%s -> %s [label="%v"]`, node.Id, child.Id, modifierType))
-			sb.WriteString("\r\n")
+			sb.WriteString("\t")
+			sb.WriteString(fmt.Sprintf(`"%s" -> "%s" [label="%v"]`, node.Id, child.Id, modifierType))
+			sb.WriteString("\n")
 		}
 	}
 	sb.WriteString("}\n")

--- a/template/faas-flow/vendor/github.com/s8sg/faas-flow/sdk/pipeline.go
+++ b/template/faas-flow/vendor/github.com/s8sg/faas-flow/sdk/pipeline.go
@@ -110,14 +110,14 @@ func (pipeline *Pipeline) MakeDotGraph() string {
 	sb.WriteString("digraph depgraph {\n\trankdir=LR;\n")
 	for _, node := range pipeline.Dag.nodes {
 		if len(node.children) == 0 {
-			sb.WriteString(fmt.Sprintf("\"%s\";\n", node.Id))
+			sb.WriteString(fmt.Sprintf("\t\"%s\";\n", node.Id))
 			continue
 		}
 		modifierType := ""
 		for _, operation := range node.Operations() {
 			switch {
 			case operation.Function != "":
-				modifierType += "(func)" + operation.Function
+				modifierType += "(func-" + operation.Function + ")"
 			case operation.CallbackUrl != "":
 				modifierType += "(callback)" + operation.CallbackUrl
 			default:


### PR DESCRIPTION
`generate-dot-graph=true` param can be used to generate graph 

Fixes: #22 

Below are example graph for async and DAG:
**Async**
```dot
digraph depgraph {
	rankdir=LR;
	"2";
	"0" -> "1" [label="(modifier)(func-facedetect)(modifier)"]
	"1" -> "2" [label="(func-colorization)"]
}
```
**DAG**
```dot
digraph depgraph {
	rankdir=LR;
	"validate-query" -> "detect-face" [label="(modifier)"]
	"validate-query" -> "colorize" [label="(modifier)"]
	"detect-face" -> "validate-and-upload" [label="(func-facedetect)"]
	"colorize" -> "compress" [label="(func-colorization)"]
	"compress" -> "validate-and-upload" [label="(func-image-resizer)"]
	"validate-and-upload";
}
```