### PR TITLE
Change function call to use gateway

### DIFF
--- a/template/faas-flow/handler.go
+++ b/template/faas-flow/handler.go
@@ -129,9 +129,9 @@ func (fhandler *flowHandler) RetriveCounter(counter string) (int, error) {
 }
 
 // buildURL builds openfaas function execution url for the flow
-func buildURL(gateway, rpath, flow string) string {
+func buildURL(gateway, rpath, function string) string {
 	u, _ := url.Parse(gateway)
-	u.Path = path.Join(u.Path, rpath+"/"+flow)
+	u.Path = path.Join(u.Path, rpath+"/"+function)
 	return u.String()
 }
 
@@ -243,7 +243,9 @@ func makeQueryStringFromParam(params map[string][]string) string {
 
 // buildFunctionRequest build upstream request for function
 func buildFunctionRequest(function string, data []byte, params map[string][]string, headers map[string]string) *http.Request {
-	url := "http://" + function + ":8080"
+	gateway := getGateway()
+	url := buildURL("http://"+gateway, "function", function)
+
 	queryString := makeQueryStringFromParam(params)
 	if queryString != "" {
 		url = url + queryString


### PR DESCRIPTION
Fixes: #66 

This PR to make function operation call via the gateway as
```
http://<gateway-url>/function/<function-name>
```
The gateway must be provided, otherwise the default will be used as
```
gateway:8080
``` 

Signed-off-by: s8sg <swarvanusg@gmail.com>