### PR TITLE
Add namespace to gatway url

### DIFF
--- a/template/faas-flow/handler.go
+++ b/template/faas-flow/handler.go
@@ -175,7 +175,7 @@ func readSecret(key string) (string, error) {
 func getGateway() string {
 	gateway := os.Getenv("gateway")
 	if gateway == "" {
-		gateway = "gateway:8080"
+		gateway = "gateway.openfaas:8080"
 	}
 	return gateway
 }


### PR DESCRIPTION
As mentioned in https://github.com/s8sg/faas-flow/issues/77 the gateway cannot be reached if it is in another namespace.
This PR adds the default namespace to the gateway url.