### PR TITLE
Add ability to pass requestId in flow with header

### DIFF
--- a/template/faas-flow/vendor/github.com/s8sg/faas-flow/sdk/exporter/exporter.go
+++ b/template/faas-flow/vendor/github.com/s8sg/faas-flow/sdk/exporter/exporter.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"fmt"
+
 	"github.com/s8sg/faas-flow/sdk"
 )
 


### PR DESCRIPTION
This adds feature to provide custom `RequestId` with `X-Faas-Flow-Reqid` header while calling the function. 

For the `sdk` user same can be achieved by setting the `RequestId` field in `RawRequest` struct  
```
// RawRequest a raw request for the flow
type RawRequest struct {
	Data          []byte
	AuthSignature string
	Query         string
	RequestId     string // RequestId is Optional, if provided faas-flow will reuse it
}
```
Fixes: #91 

Signed-off-by: s8sg <swarvanusg@gmail.com>